### PR TITLE
Update Examples.md

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -657,6 +657,8 @@ spec:
   defaultsUrl: /mnt/license-manager/default.yml
 ```
 
+In the case of an indexer cluster, default.yml will need configuration on the cluster manager custom resource and all indexer cluster custom resource(s)
+
 ## Using an External Indexer Cluster
 
 *Note that this requires using the Splunk Enterprise container version 8.1.0 or later*


### PR DESCRIPTION
Adding additional context around the use of the external license manager settings as the previous section advises "you need to add licenseManagerRef only to the ClusterManager spec as follows:"

Which is not the case for external cluster managers